### PR TITLE
1.21.6-1.21.10 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.9-SNAPSHOT'
+	id 'fabric-loom' version '1.13-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
-loader_version=0.16.9
-midnightlib_version = 1.6.6-fabric
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.3
+loader_version=0.18.1
+midnightlib_version = 1.9.1+1.21.10-fabric
 
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.2
 maven_group=net.countered.settlementroads
 archives_base_name=settlement-roads
 
 # Dependencies
-fabric_version=0.114.1+1.21.4
+fabric_version=0.138.0+1.21.10

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/countered/settlementroads/events/ModEventHandler.java
+++ b/src/main/java/net/countered/settlementroads/events/ModEventHandler.java
@@ -77,9 +77,7 @@ public class ModEventHandler {
         });
     }
 
-    private static final ChunkTicketType<BlockPos> ROAD_TICKET = ChunkTicketType.create("road_ticket", Comparator.comparingLong(BlockPos::asLong));
-    private static final Set<ChunkPos> toRemove = ConcurrentHashMap.newKeySet();
-    private static final int MAX_BLOCKS_PER_TICK = 1;
+
 
     private static void loadRoadChunksCompletely(ServerWorld serverWorld) {
         if (!RoadFeature.roadChunksCache.isEmpty()) {
@@ -97,9 +95,9 @@ public class ModEventHandler {
                 Block blockAbove = worldChunk.getBlockState(postProcessingPos.up()).getBlock();
                 Block blockAtPos = worldChunk.getBlockState(postProcessingPos).getBlock();
                 if (blockAbove == Blocks.SNOW) {
-                    worldChunk.setBlockState(postProcessingPos.up(), Blocks.AIR.getDefaultState(), false);
+                    worldChunk.setBlockState(postProcessingPos.up(), Blocks.AIR.getDefaultState(), 3);
                     if (blockAtPos == Blocks.GRASS_BLOCK) {
-                        worldChunk.setBlockState(postProcessingPos, Blocks.GRASS_BLOCK.getDefaultState(), false);
+                        worldChunk.setBlockState(postProcessingPos, Blocks.GRASS_BLOCK.getDefaultState(), 3);
                     }
                 }
                 RoadFeature.roadPostProcessingPositions.remove(postProcessingPos);

--- a/src/main/java/net/countered/settlementroads/helpers/StructureLocator.java
+++ b/src/main/java/net/countered/settlementroads/helpers/StructureLocator.java
@@ -88,8 +88,9 @@ public class StructureLocator {
     }
 
     private static void addTagStructurePersistent(ServerWorld serverWorld, TagKey<Structure> structureTag, @Nullable ServerPlayerEntity player) {
+        BlockPos spawnPos = BlockPos.ORIGIN;
         BlockPos structureLocation = player != null ? serverWorld.locateStructure(structureTag, player.getBlockPos(), 50, true) :
-                                     serverWorld.locateStructure(structureTag, serverWorld.getSpawnPos(), 50, true);
+                                     serverWorld.locateStructure(structureTag, spawnPos, 50, true);
         if (structureLocation != null) {
             LOGGER.info(ModConfig.structureToLocate + " found at " + "/tp " + structureLocation.getX() + " " + 100 + " " + structureLocation.getZ());
             ModEventHandler.getRoadData(serverWorld).getStructureLocations().add(structureLocation);
@@ -100,12 +101,13 @@ public class StructureLocator {
     }
 
     private static void addKeyStructurePersistent(ServerWorld serverWorld, RegistryEntryList<Structure> registryEntryList, @Nullable ServerPlayerEntity player) {
+        BlockPos spawnPos = BlockPos.ORIGIN;
         Pair<BlockPos, RegistryEntry<Structure>> structureLocation = player != null ? serverWorld.getChunkManager()
                 .getChunkGenerator()
                 .locateStructure(serverWorld, registryEntryList, player.getBlockPos(), 50, true):
                 serverWorld.getChunkManager()
                         .getChunkGenerator()
-                        .locateStructure(serverWorld, registryEntryList, serverWorld.getSpawnPos(), 50, true);
+                        .locateStructure(serverWorld, registryEntryList, spawnPos, 50, true);
         if (structureLocation != null) {
             LOGGER.info("Structure found at " + structureLocation);
             ModEventHandler.getRoadData(serverWorld).getStructureLocations().add(structureLocation.getFirst());

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
 	"schemaVersion": 1,
 	"id": "settlement-roads",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"name": "Countered's Settlement Roads",
 	"description": "A mod to generate roads between structures!",
 	"authors": [
@@ -27,7 +27,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.16.9",
-		"minecraft": "~1.21.4",
+		"minecraft": ">=1.21.4 <=1.21.10",
 		"java": ">=21",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
RU:
build.gradle - обновил Fabric Loom с 1.9 на 1.13
gradle.properties - обновил все версии (MC 1.21.10, Fabric API, Loader, MidnightLib) gradle/wrapper/gradle-wrapper.properties - обновил Gradle с 8.11.1 на 8.14 src/main/resources/fabric.mod.json - изменил версию мода на 1.0.2 и диапазон MC на >=1.21.4 <=1.21.10 src/main/java/net/countered/settlementroads/events/ModEventHandler.java - исправил API (setBlockState, удалил неиспользуемые поля) src/main/java/net/countered/settlementroads/helpers/StructureLocator.java - исправил getSpawnPoint() на BlockPos.ORIGIN src/main/java/net/countered/settlementroads/persistence/RoadData.java - обновил PersistentState API, добавил Codec, исправил NbtCompound методы

===
EN:
build.gradle - updated Fabric Loom from 1.9 to 1.13 gradle.properties - updated all versions (MC 1.21.10, Fabric API, Loader, MidnightLib) gradle/wrapper/gradle-wrapper.properties - updated Gradle from 8.11.1 to 8.14 src/main/resources/fabric.mod.json - changed the mod version to 1.0.2 and the MC range to >=1.21.4 <=1.21.10 src/main/java/net/countered/settlements/events/ModEventHandler.java - fixed API (setBlockState, deleted unused fields) src/main/java/net/countered/settementroads/helpers/StructureLocator.java - fixed getSpawnPoint() on BlockPos.ORIGIN src/main/java/net/countered/settlementroads/persistence/RoadData.java - updated the PersistentState API, added Codec, fixed NbtCompound methods